### PR TITLE
added: podman compose file so netpicker can run succefully with podman

### DIFF
--- a/podman/compose.yml
+++ b/podman/compose.yml
@@ -1,0 +1,258 @@
+# Netpicker - rootless Podman compose file.
+# Run from the repo root so relative paths resolve;
+# podman compose -f podman/compose.yml up -d
+# or just: ./podman/up.sh
+#
+# Prerequisites (run once, as the rootless user);
+# systemctl --user enable --now podman.socket
+# Enable linger;     
+# loginctl enable-linger "$USER"               
+#
+# See podman.md 
+
+x-api: &api_common_no_deps
+  image: "netpicker/api:latest"
+  environment:
+    alembic_version: "head"
+    CLI_PROXY_HOST: agent
+    LOG_LEVEL: INFO
+    UVICORN_ROOT_PATH: /
+    PROXY_SSL_VERIFY: 0
+  volumes:
+    - policy-data:/data
+    - ${XDG_RUNTIME_DIR}/podman/podman.sock:/var/run/docker.sock:Z
+
+x-api-deps: &api_common
+  <<: *api_common_no_deps
+  depends_on:
+    db:
+      condition: service_healthy
+    gitd:
+      condition: service_started
+    gitdctrl:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+    db_migration:
+      condition: service_completed_successfully
+
+services:
+  agent:
+    hostname: agent
+    image: "netpicker/agent:latest"
+    container_name: agent
+    labels:
+      netpicker.io: service
+      service.netpicker.io: agent
+    environment:
+      CLI_PROXY_ADDR: "0.0.0.0"
+      SHARED_SSH_TTL: 180
+      NO_PROXY: "api,frontend"
+      NETPICKER_GIT_URL: "http://frontend:8081/git"
+    volumes:
+      - secret:/run/secrets
+      - dc-vol:/dc-vol
+    restart: always
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: "echo LST | nc -v 127.0.0.1 8765"
+      start_period: 12s
+      interval: 10s
+
+  api:
+    <<: *api_common
+    container_name: api
+    labels:
+      netpicker.io: service
+      service.netpicker.io: api
+    ports:
+      - "8000:8000"
+    restart: always
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python3",
+          "-c",
+          "import requests; requests.get('http://localhost:8000/api/v1/status').raise_for_status()",
+        ]
+      start_period: 60s
+      interval: 5s
+      retries: 5
+      timeout: 10s
+
+  celery:
+    <<: *api_common
+    depends_on:
+      api:
+        condition: service_healthy
+    container_name: celery
+    labels:
+      netpicker.io: service
+      service.netpicker.io: celery
+    command: /run-celery
+    restart: always
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "CELERY_BROKER_URL=redis://redis celery inspect ping -t 5",
+        ]
+      start_period: 15s
+      interval: 30s
+
+  db:
+    image: netpicker/db
+    container_name: db
+    labels:
+      netpicker.io: service
+    environment:
+      POSTGRES_PASSWORD: s3rgts0p!
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U netpicker"]
+      interval: 30s
+      timeout: 60s
+      retries: 5
+      start_period: 80s
+
+  db_migration:
+    <<: *api_common_no_deps
+    command: /db-migrate
+    depends_on:
+      db:
+        condition: service_healthy
+
+  frontend:
+    image: "netpicker/tester-frontend:latest"
+    container_name: frontend
+    labels:
+      netpicker.io: service
+      service.netpicker.io: front-end
+    ports:
+      - "8081:8081"
+    volumes:
+      - git:/git
+      # nginx image regenerates conf.d/default.conf from this template on
+      # startup; mounting onto conf.d directly fails (can't overwrite a bind mount).
+      - ./default.conf:/etc/nginx/templates/default.conf.template:ro,Z
+    restart: always
+    depends_on:
+      - api
+
+  gitd:
+    image: "netpicker/gitd:latest"
+    container_name: gitd
+    labels:
+      netpicker.io: service
+      service.netpicker.io: gitd
+    restart: always
+    volumes:
+      - git:/git
+
+  gitdctrl:
+    image: "netpicker/gitdctrl:latest"
+    container_name: gitdctrl
+    labels:
+      netpicker.io: service
+      service.netpicker.io: gitdctrl
+    volumes:
+      - git:/git
+    healthcheck:
+      test: echo "PING" | nc -v localhost 9419
+      start_period: 5s
+      interval: 5s
+    restart: always
+
+  kibbitzer:
+    image: "netpicker/kibbitzer:latest"
+    container_name: kibbitzer
+    labels:
+      netpicker.io: service
+      service.netpicker.io: kibbitzer
+    environment:
+      LOG_LEVEL: INFO
+      SHENV_API_URL: http://api:8000
+      SHENV_API_TIMEOUT: 30
+      SHENV_PRIVILEGED_PLATFORMS: "gigamon_gigavue arista_eos"
+      SHENV_SHOW_RUN_aruba_os: "show configuration"
+      SHENV_SHOW_RUN_corvil: "show config"
+      SHENV_SHOW_RUN_gigamon: "show running"
+      SHENV_SHOW_RUN_meinberg: "generate_config_backup && cat /var/tmp/lantime_config.backup"
+      SHENV_SHOW_RUN_mikrotik_routeros: "export"
+      SHENV_SHOW_RUN_nokia_srl: "info"
+      SHENV_SHOW_RUN_paloalto_panos: "show config running"
+      SHENV_TAG_SHOW_RUN_mikrotik_routeros_v7: "export show-sensitive"
+    healthcheck:
+      test: echo "ping Mac\n" | nc -v 127.0.0.1 9696
+      start_period: 15s
+      interval: 30s
+    volumes:
+      - secret:/run/secrets
+      - transferium:/transferium
+      - dc-vol:/dc-vol
+      - kibbitzer:/celery-worker
+      - ../textfsm:/textfsm:Z
+    restart: always
+    depends_on:
+      - api
+      - redis
+
+  redis:
+    image: redis:7-alpine3.21
+    container_name: redis
+    labels:
+      netpicker.io: service
+    volumes:
+      - redis:/data
+    command: "--save 60 1 --loglevel warning"
+    restart: always
+    healthcheck:
+      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+
+  swagger:
+    image: swaggerapi/swagger-ui
+    container_name: swagger
+    environment:
+      SWAGGER_JSON_URL: "/openapi.json"
+      TRY_IT_OUT_ENABLED: 1
+    restart: always
+    depends_on:
+      - api
+
+  syslog-ng:
+    image: "netpicker/syslog-ng:latest"
+    container_name: syslog-ng
+    labels:
+      netpicker.io: service
+      service.netpicker.io: syslog-ng
+    # syslog-ng inside the container binds privileged ports 514 (udp) and 601
+    # (tcp). Under rootless Podman the process (uid 911) cannot bind <1024,
+    # which is why this container exits with code 2 on Podman. Allowing
+    # unprivileged low ports inside the container's own net namespace fixes it.
+    sysctls:
+      net.ipv4.ip_unprivileged_port_start: "0"
+    ports:
+      - 5514:514/udp
+      - 6601:601/tcp
+      - 6514:6614/tcp
+    volumes:
+      - syslog:/var/lib/syslog-ng
+    restart: always
+    depends_on:
+      - agent
+
+volumes:
+  dc-vol:
+  git:
+  kibbitzer:
+  pg_data:
+  policy-data:
+  redis:
+  secret:
+  syslog:
+  transferium:

--- a/podman/podman.md
+++ b/podman/podman.md
@@ -1,42 +1,41 @@
-# Netpicker - Podman Compatibility Changes
+# Netpicker on rootless Podman
 
-Podman rootless runs containers as a non-root user, causing permission issues that don't occur in Docker. The following changes are required.
+Rootless Podman runs as a non-root user, so privileged ports and bind mounts
+that work on Docker break. [`compose.yml`](compose.yml) is a separate file with
+the fixes below; `docker-compose.yml` is left for Docker.
 
-## Frontend (tester-frontend)
+## Run
 
-### Problem
+```bash
+./podman/up.sh
+# or;
+systemctl --user enable --now podman.socket
+podman compose -f podman/compose.yml up -d
+```
 
-Nginx cannot bind to port 80 inside the container (privileged port).
+Frontend: http://localhost:8081
 
-### Solution
+## Fixes
 
-1. Create a custom [`default.conf`](default.conf) with nginx listening on port 8081 instead of 80
-2. Mount it into the container and update the port mapping in `docker-compose.yml`:
+**Frontend**; can't bind port 80 (host or container). [`default.conf`](default.conf)
+moves nginx to 8081; compose maps `8081:8081`.
 
-   ```yaml
-   frontend:
-     ports:
-       - '8081:8081'
-     volumes:
-       - ./default.conf:/etc/nginx/conf.d/default.conf:Z
-   ```
+**Agent**; default git URL assumes port 80. Set `NETPICKER_GIT_URL: http://frontend:8081/git`.
 
-> The `:Z` mount option is required for Podman to apply the correct SELinux label so the container process can read the file.
+**api / celery**; mount the Podman socket instead of the (nonexistent) Docker
+socket; `${XDG_RUNTIME_DIR}/podman/podman.sock:/var/run/docker.sock:Z`, and drop
+`group_add`. Needs `systemctl --user enable --now podman.socket`. Only powers the
+in-app service-status panel; the stack runs without it.
 
-Note that Podman rootless binds to `0.0.0.0`.
+**syslog-ng**; cant bind ports 514/601 (exits with code 2). Allow low ports:
+`sysctls: { net.ipv4.ip_unprivileged_port_start: "0" }`.
 
-## Agent
+**kibbitzer textfsm**; add `:Z` to the `./textfsm` bind mount or SELinux blocks reads.
 
-### Problem
+`:Z` on a bind mount tells Podman to set the SELinux label so the container can
+read it.
 
-The agent's default git URL (`http://frontend/git`) assumes port 80, which no longer works when nginx listens on 8081.
+## Not handled
 
-### Solution
-
-Set the `NETPICKER_GIT_URL` environment variable in `docker-compose.yml`:
-
-   ```yaml
-   agent:
-     environment:
-       NETPICKER_GIT_URL: 'http://frontend:8081/git'
-   ```
+`backup.sh`, `restore.sh`, `fix-volume-permissions.sh` are Docker only and assume
+no UID offset. Rootless maps uid 911 to ~100910 on the host; adapt before use.

--- a/podman/up.sh
+++ b/podman/up.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Bring up Netpicker under rootless Podman. Run from the repo root: ./podman/up.sh
+set -e
+
+# The api/celery "system services" panel talks to the Podman socket.
+systemctl --user enable --now podman.socket
+# Keep the user services running after logout.
+loginctl enable-linger "$USER" 2>/dev/null || true
+
+export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/run/user/$(id -u)}
+
+PROJECT=netpicker
+COMPOSE=(podman compose -p "$PROJECT" -f podman/compose.yml)
+
+"${COMPOSE[@]}" down
+
+# These volumes are written by services running as uid 911, but rootless Podman
+# creates volumes owned by root. Create and chown them before starting.
+for v in git policy-data secret dc-vol transferium kibbitzer syslog; do
+  podman volume exists "${PROJECT}_$v" || podman volume create "${PROJECT}_$v" >/dev/null
+  podman run --rm -v "${PROJECT}_$v":/v docker.io/library/alpine chown -R 911:911 /v
+done
+
+"${COMPOSE[@]}" up -d
+
+echo
+echo "Netpicker is starting. Frontend: http://localhost:8081"


### PR DESCRIPTION
- frontend; nginx can't bind port 80. Switchedd to 8081 and mount default.conf as the nginx template (mounting onto conf.d directly fails because the image regenerates it at boot)
- agent; point NETPICKER_GIT_URL at http://frontend:8081/git
- api / celery; mount the rootless Podman socket at /var/run/docker.sock (docker api compatible)
- syslog-ng; was exiting code 2; allow low ports via sysctl net.ipv4.ip_unprivileged_port_start=0
- kibbitzer; add :Z to the textfsm bind mount so SELinux allows reads
- volumes; up.sh creates and chown 911 the seven service-owned volumes (git, policy-data, secret, dc-vol, transferium, kibbitzer, syslog) before start; project pinned to netpicker for deterministiic names